### PR TITLE
reduce DBUS permissions for the KDE tray

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -45,13 +45,9 @@ finish-args:
   # access, obviously
   - --share=network
   #
-  # System tray icon doesn't work, but when/if it does, that would be
-  # the way:
   ## Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  ## Required for tray icons on KDE
-  - --own-name=org.kde.*
   # MPRIS2 support
   ## cargo-cult from io.mpv.Mpv and org.videolan.VLC
   - --talk-name=org.mpris.MediaPlayer2.Player


### PR DESCRIPTION
Those seem overly abusive. I haven't heard reports of the tray working or not, so let's be on the careful side for now. If that fails, we can revert to the broader scope.

I used this to do an inventory:

https://github.com/search?q=org%3Aflathub+--own-name%3Dorg.kde&type=code

Some also use `--talk-name` but less frequently, and we already do have such an entry.