### PR TITLE
[MPRIS] fix case of dbus own-name

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -51,7 +51,7 @@ finish-args:
   # MPRIS2 support
   ## cargo-cult from io.mpv.Mpv and org.videolan.VLC
   - --talk-name=org.mpris.MediaPlayer2.Player
-  - --own-name=org.mpris.MediaPlayer2.supersonic
+  - --own-name=org.mpris.MediaPlayer2.Supersonic
   #
   # maybe this would be necessary once media keys are fully supported
   # on their own: https://github.com/dweymouth/supersonic/issues/56


### PR DESCRIPTION
I don't know if dbus is case-sensitive or not, but the MPRIS name used by Supersonic is "Supersonic" not "supersonic". Maybe this will fix the no MPRIS in Flatpak