### PR TITLE
Revert mpv upgrade, causing regression

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -89,8 +89,8 @@ modules:
       - /lib/pkgconfig
     sources:
       - type: archive
-        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz
-        sha256: 1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf
+        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.36.0.tar.gz
+        sha256: 29abc44f8ebee013bb2f9fe14d80b30db19b534c679056e4851ceadf5a5e8bf6
         x-checker-data:
           type: anitya
           project-id: 5348
@@ -117,21 +117,6 @@ modules:
           - /include
           - /lib/pkgconfig
           - /share
-      - name: libplacebo
-        buildsystem: meson
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-        sources:
-          - type: git
-            url: https://code.videolan.org/videolan/libplacebo.git
-            mirror-urls:
-              - https://github.com/haasn/libplacebo.git
-            tag: v6.338.1
-            commit: 2805a0d01c029084ab36bf5d0e3c8742012a0b27
-            x-checker-data:
-              type: git
-              tag-pattern: ^v([\d.]+)$
       - name: ffmpeg
         cleanup:
           - /include


### PR DESCRIPTION
This reverts commit a65514941092556109e7043688155d23792b8677. This reverts commit fb172f8e5dfca09404dd2e412cfeef3271cc069b.

See https://github.com/dweymouth/supersonic/issues/289 for discussion.