### PR TITLE
try to skip spirv dependency

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -84,6 +84,7 @@ modules:
       - -Dsdl2=disabled
       - -Dshaderc=disabled
       - -Dvulkan=disabled
+      - -Dspirv-cross=disabled
     cleanup:
       - /include
       - /lib/pkgconfig


### PR DESCRIPTION
An attempt at fixing
https://github.com/dweymouth/supersonic/issues/289 without reverting the upgrade.

The io.mpv flatpak doesn't have that issue because it builds shaderc/vulkan and its deps.