### PR TITLE
build libplacebo like mpv flatpak

### DIFF
--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -34,6 +34,10 @@ modules:
   - name: libass
     config-opts:
       - --disable-static
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share
     sources:
       - type: archive
         url: https://github.com/libass/libass/releases/download/0.17.1/libass-0.17.1.tar.xz
@@ -47,10 +51,6 @@ modules:
         commands:
           - autoreconf -fiv
         dest-filename: autogen.sh
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /share
   - name: libplacebo
     buildsystem: meson
     cleanup:

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -68,43 +68,29 @@ modules:
           project-id: 20101
           stable-only: true
           url-template: https://code.videolan.org/videolan/libplacebo/-/archive/v$version/libplacebo-v$version.tar.gz
-      - type: archive
-        url: https://github.com/pallets/markupsafe/archive/refs/tags/2.1.3.tar.gz
-        sha256: b209e55e953eabf4bc31e0c9f3182af03b40e5bf5afed652f72b9b7ac02c0b30
-        dest: 3rdparty/markupsafe
-        x-checker-data:
-          type: anitya
-          stable-only: true
-          project-id: 3918
-          url-template: https://github.com/pallets/markupsafe/archive/refs/tags/$version.tar.gz
-      - type: archive
-        url: https://github.com/pallets/jinja/archive/refs/tags/3.1.2.tar.gz
-        sha256: ecae76cd1a064d40eb46c5375f07953d747f4d65b68cd3fa5f02c91714b799fc
-        dest: 3rdparty/jinja
-        x-checker-data:
-          type: anitya
-          project-id: 3894
-          stable-only: true
-          url-template: https://github.com/pallets/jinja/archive/refs/tags/$version.tar.gz
-      - type: archive
-        url: https://github.com/Dav1dde/glad/archive/refs/tags/v2.0.4.tar.gz
-        sha256: 02629644c242dcc27c58222bd2c001d5e2f3765dbbcfd796542308bddebab401
-        dest: 3rdparty/glad
-        x-checker-data:
-          type: anitya
-          stable-only: true
-          project-id: 20607
-          url-template: https://github.com/Dav1dde/glad/archive/refs/tags/$version.tar.gz
     modules:
-      - name: glslang
+      - name: shaderc
         buildsystem: cmake-ninja
+        builddir: true
         config-opts:
-          - -DBUILD_SHARED_LIBS=ON
+          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+          - -DSHADERC_SKIP_EXAMPLES=ON
+          - -DSHADERC_SKIP_TESTS=ON
+          - -DSPIRV_SKIP_EXECUTABLES=ON
+          - -DENABLE_GLSLANG_BINARIES=OFF
         cleanup:
           - /bin
           - /include
           - /lib/cmake
+          - /lib/pkgconfig
         sources:
+          - type: git
+            url: https://github.com/google/shaderc.git
+            tag: v2023.7
+            commit: 3882b16417077aa8eaa7b5775920e7ba4b8a224d
+            x-checker-data:
+              type: git
+              tag-pattern: ^v(\d{4}\.\d{1,2})$
           - type: archive
             url: https://github.com/KhronosGroup/glslang/archive/13.1.1.tar.gz
             sha256: 1c4d0a5a38c8aaf89a2d7e6093be734320599f5a6775b2726beeb05b0c054e66

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -68,6 +68,15 @@ modules:
           project-id: 20101
           stable-only: true
           url-template: https://code.videolan.org/videolan/libplacebo/-/archive/v$version/libplacebo-v$version.tar.gz
+      - type: archive
+        url: https://github.com/Dav1dde/glad/archive/refs/tags/v2.0.4.tar.gz
+        sha256: 02629644c242dcc27c58222bd2c001d5e2f3765dbbcfd796542308bddebab401
+        dest: 3rdparty/glad
+        x-checker-data:
+          type: anitya
+          stable-only: true
+          project-id: 20607
+          url-template: https://github.com/Dav1dde/glad/archive/refs/tags/$version.tar.gz
     modules:
       - name: shaderc
         buildsystem: cmake-ninja

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -127,15 +127,6 @@ modules:
               type: git
               tag-pattern: ^v(\d{4}\.\d{1,2})$
           - type: archive
-            url: https://github.com/KhronosGroup/glslang/archive/13.1.1.tar.gz
-            sha256: 1c4d0a5a38c8aaf89a2d7e6093be734320599f5a6775b2726beeb05b0c054e66
-            dest: third_party/glslang
-            x-checker-data:
-              type: anitya
-              project-id: 205796
-              stable-only: true
-              url-template: https://github.com/KhronosGroup/glslang/archive/$version.tar.gz
-          - type: archive
             url: https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/sdk-1.3.261.1.tar.gz
             sha256: ead95c626ad482882a141d1aa0ce47b9453871f72c42c0b28d39c82f60a52008
             dest: third_party/spirv-tools
@@ -153,6 +144,15 @@ modules:
               stable-only: true
               project-id: 334920
               url-template: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-$version.tar.gz
+          - type: archive
+            url: https://github.com/KhronosGroup/glslang/archive/13.1.1.tar.gz
+            sha256: 1c4d0a5a38c8aaf89a2d7e6093be734320599f5a6775b2726beeb05b0c054e66
+            dest: third_party/glslang
+            x-checker-data:
+              type: anitya
+              project-id: 205796
+              stable-only: true
+              url-template: https://github.com/KhronosGroup/glslang/archive/$version.tar.gz
   - name: ffmpeg
     cleanup:
       - /include

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -129,6 +129,7 @@ modules:
           - type: archive
             url: https://github.com/KhronosGroup/glslang/archive/13.1.1.tar.gz
             sha256: 1c4d0a5a38c8aaf89a2d7e6093be734320599f5a6775b2726beeb05b0c054e66
+            dest: third_party/glslang
             x-checker-data:
               type: anitya
               project-id: 205796
@@ -137,7 +138,7 @@ modules:
           - type: archive
             url: https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/sdk-1.3.261.1.tar.gz
             sha256: ead95c626ad482882a141d1aa0ce47b9453871f72c42c0b28d39c82f60a52008
-            dest: External/spirv-tools
+            dest: third-party/spirv-tools
             x-checker-data:
               type: anitya
               stable-only: true
@@ -146,7 +147,7 @@ modules:
           - type: archive
             url: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-1.3.261.1.tar.gz
             sha256: 32b4c6ae6a2fa9b56c2c17233c8056da47e331f76e117729925825ea3e77a739
-            dest: External/spirv-tools/external/spirv-headers
+            dest: third-party/spirv-headers
             x-checker-data:
               type: anitya
               stable-only: true

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -20,6 +20,8 @@ config-opts:
 cleanup:
   - /include
   - /lib/pkgconfig
+  - '*.la'
+  - '*.a'
 sources:
   - type: archive
     url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz
@@ -38,6 +40,8 @@ modules:
       - /include
       - /lib/pkgconfig
       - /share
+      - '*.la'
+      - '*.a'
     sources:
       - type: archive
         url: https://github.com/libass/libass/releases/download/0.17.1/libass-0.17.1.tar.xz
@@ -56,6 +60,8 @@ modules:
     cleanup:
       - /include
       - /lib/pkgconfig
+      - '*.la'
+      - '*.a'
     config-opts:
       - -Dd3d11=disabled
       - -Ddemos=False
@@ -110,6 +116,8 @@ modules:
           - /include
           - /lib/cmake
           - /lib/pkgconfig
+          - '*.la'
+          - '*.a'
         sources:
           - type: git
             url: https://github.com/google/shaderc.git
@@ -149,6 +157,8 @@ modules:
       - /include
       - /lib/pkgconfig
       - /share/ffmpeg/examples
+      - '*.la'
+      - '*.a'
     config-opts:
     # this is almost like io.mpv.Mpv, except we removed:
     # --enable-libbs2b

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -69,6 +69,24 @@ modules:
           stable-only: true
           url-template: https://code.videolan.org/videolan/libplacebo/-/archive/v$version/libplacebo-v$version.tar.gz
       - type: archive
+        url: https://github.com/pallets/markupsafe/archive/refs/tags/2.1.3.tar.gz
+        sha256: b209e55e953eabf4bc31e0c9f3182af03b40e5bf5afed652f72b9b7ac02c0b30
+        dest: 3rdparty/markupsafe
+        x-checker-data:
+          type: anitya
+          stable-only: true
+          project-id: 3918
+          url-template: https://github.com/pallets/markupsafe/archive/refs/tags/$version.tar.gz
+      - type: archive
+        url: https://github.com/pallets/jinja/archive/refs/tags/3.1.2.tar.gz
+        sha256: ecae76cd1a064d40eb46c5375f07953d747f4d65b68cd3fa5f02c91714b799fc
+        dest: 3rdparty/jinja
+        x-checker-data:
+          type: anitya
+          project-id: 3894
+          stable-only: true
+          url-template: https://github.com/pallets/jinja/archive/refs/tags/$version.tar.gz
+      - type: archive
         url: https://github.com/Dav1dde/glad/archive/refs/tags/v2.0.4.tar.gz
         sha256: 02629644c242dcc27c58222bd2c001d5e2f3765dbbcfd796542308bddebab401
         dest: 3rdparty/glad

--- a/modules/mpv.yml
+++ b/modules/mpv.yml
@@ -138,7 +138,7 @@ modules:
           - type: archive
             url: https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/sdk-1.3.261.1.tar.gz
             sha256: ead95c626ad482882a141d1aa0ce47b9453871f72c42c0b28d39c82f60a52008
-            dest: third-party/spirv-tools
+            dest: third_party/spirv-tools
             x-checker-data:
               type: anitya
               stable-only: true
@@ -147,7 +147,7 @@ modules:
           - type: archive
             url: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-1.3.261.1.tar.gz
             sha256: 32b4c6ae6a2fa9b56c2c17233c8056da47e331f76e117729925825ea3e77a739
-            dest: third-party/spirv-headers
+            dest: third_party/spirv-headers
             x-checker-data:
               type: anitya
               stable-only: true


### PR DESCRIPTION
This should reduce the build / install size. The actual way the libs are changed doesn't actually change the build size at all, but the way it's done in mpv is more streamlined, and it's worth reducing the diff with them.

But what's capital here is the removal of `.a` files which are gigantic, particularly for SPIRV.

Closes: #42
