### PR TITLE
Allow pipewire device visibility

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -33,6 +33,7 @@ finish-args:
   #
   # audio playback
   - --socket=pulseaudio
+  - --filesystem=xdg-run/pipewire-0:ro
   #
   # Required to store access tokens (persistent logins)
   - --filesystem=xdg-run/keyring


### PR DESCRIPTION
allow readonly access to $XDG_RUNTIME_DIR/pipewire-0 this allows pipewire devices to show up in addition to pulseaudio or pulse-wrapped

Fixes #44 