### PR TITLE
 Desktop file test (beta)

### DIFF
--- a/go.mod.yml
+++ b/go.mod.yml
@@ -34,10 +34,10 @@
   sha256: c3060358e7d6e5027edb8d61f0a101de6e4930e3ad378023444dc10afc6cb484
 
 - type: archive
-  url: https://proxy.golang.org/github.com/dweymouth/go-subsonic/@v/v0.0.0-20231216015633-3797c9b3d94d.zip
+  url: https://proxy.golang.org/github.com/dweymouth/go-subsonic/@v/v0.0.0-20231216234924-3f62122dc53a.zip
   strip-components: 3
   dest: vendor/github.com/dweymouth/go-subsonic
-  sha256: 4922efc28762c2ea5f647cac6ea5411e71a458071e17f41c6463ec1a23b72b52
+  sha256: b2284d5414c01e556741ff29395ec7f3a6c95f9949de66b45006fed69124bdac
 
 - type: archive
   url: https://proxy.golang.org/github.com/fsnotify/fsnotify/@v/v1.6.0.zip

--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -95,7 +95,8 @@ modules:
       - tar -C /app --strip-components=1 -x -v -f /run/build/supersonic/Supersonic.tar.xz
       - mkdir -p /app/share/icons/hicolor/512x512/apps/
       - mv /app/share/pixmaps/Supersonic.png /app/share/icons/hicolor/512x512/apps/
-      - desktop-file-edit --set-key=Icon --set-value=$FLATPAK_ID /app/share/applications/Supersonic.desktop
+      - install -Dm644 res/supersonic-desktop.desktop /app/share/applications/$FLATPAK_ID.desktop
+      - desktop-file-edit --set-key=Icon --set-value=$FLATPAK_ID /app/share/applications/$FLATPAK_ID.desktop
       # io.mpv.Mpv has a neat trick to automatically update the
       # version too, see:
       # https://github.com/flathub/io.mpv.Mpv/blob/master/io.mpv.Mpv.yml#L606-L617

--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -103,8 +103,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/dweymouth/supersonic/
-        commit: becb34cd4a575f2f952046e61fce30e513e2e2c8
-        tag: v0.8.2
+        commit: 61f5f24c4f58f499f6429dcd9d668d4900c46001
+        branch: main
         x-checker-data:
           type: git
           # taken from Debian's uscan(1) @ANY_VERSION@ pattern,

--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -8,7 +8,10 @@ sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
 command: supersonic
-rename-desktop-file: Supersonic.desktop
+# this is actually overriden below, because the upstream desktop file
+# is broken, see:
+# https://github.com/flathub/io.github.dweymouth.supersonic/issues/47#issuecomment-1864804405
+#rename-desktop-file: Supersonic.desktop
 rename-icon: Supersonic
 
 finish-args:
@@ -95,6 +98,8 @@ modules:
       - tar -C /app --strip-components=1 -x -v -f /run/build/supersonic/Supersonic.tar.xz
       - mkdir -p /app/share/icons/hicolor/512x512/apps/
       - mv /app/share/pixmaps/Supersonic.png /app/share/icons/hicolor/512x512/apps/
+      # broken Fyne-generated desktop file
+      - rm /app/share/applications/Supersonic.desktop
       - install -Dm644 res/supersonic-desktop.desktop /app/share/applications/$FLATPAK_ID.desktop
       - desktop-file-edit --set-key=Icon --set-value=$FLATPAK_ID /app/share/applications/$FLATPAK_ID.desktop
       # io.mpv.Mpv has a neat trick to automatically update the

--- a/modules.txt
+++ b/modules.txt
@@ -67,7 +67,7 @@ github.com/dweymouth/go-jellyfin
 # github.com/dweymouth/go-mpv v0.0.0-20230406003141-7f1858e503ee
 ## explicit
 github.com/dweymouth/go-mpv
-# github.com/dweymouth/go-subsonic v0.0.0-20231216015633-3797c9b3d94d
+# github.com/dweymouth/go-subsonic v0.0.0-20231216234924-3f62122dc53a
 ## explicit; go 1.13
 github.com/dweymouth/go-subsonic/subsonic
 # github.com/fredbi/uri v1.0.0


### PR DESCRIPTION
This MR brings the "beta" branch up to date with the 0.8.2 flatpak and syncs with the latest upstream (currently https://github.com/dweymouth/supersonic/commit/61f5f24c4f58f499f6429dcd9d668d4900c46001) to see if it will fix the menu category.

Closes: #47

/cc @webmind