### PR TITLE
Allow pipewire config access

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -37,7 +37,7 @@ finish-args:
   # audio playback
   - --socket=pulseaudio
   - --filesystem=xdg-run/pipewire-0:ro
-  - --filesystem=xdg-config/pipewire:ro
+  - --filesystem=~/.config/pipewire:ro
   #
   # Required to store access tokens (persistent logins)
   - --filesystem=xdg-run/keyring

--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -37,6 +37,7 @@ finish-args:
   # audio playback
   - --socket=pulseaudio
   - --filesystem=xdg-run/pipewire-0:ro
+  - --filesystem=xdg-config/pipewire:ro
   #
   # Required to store access tokens (persistent logins)
   - --filesystem=xdg-run/keyring


### PR DESCRIPTION
Previously I added the pipewire runtime filesystem
After a frustrating bit of debugging related to tuning resampling, I realized that not all config information is loaded by the daemons.
In particular, client config, such as for `client-rt.conf` and the specific section overrides in the appropriate subdir (once that gets properly working) need to be readable by the client, in this case `supersonic` under flatpak
So we need to add the pipewire config directory, and read-only is fine

NOTE for anyone who finds this looking for `pipewire` and `supersonic`...
It turns out turning `socket=pulseaudio` OFF will greatly declutter the Audio Device chooser menu if you're all in on pipewire, but that isn't wise for a default deployment.  Use Flatseal or add  `sockets=!pulseaudio` to your flatpak overrides if you wish.