### PR TITLE
Add migrated_fynedo to Flatpak build

### DIFF
--- a/io.github.dweymouth.supersonic.yml
+++ b/io.github.dweymouth.supersonic.yml
@@ -90,9 +90,9 @@ modules:
         GOBIN: /app/bin
         GO11MODULE: off
     build-commands:
-      - . /usr/lib/sdk/golang/enable.sh && CGO_LDFLAGS=-L/app/lib go build -v .
+      - . /usr/lib/sdk/golang/enable.sh && CGO_LDFLAGS=-L/app/lib go build -v -tags migrated_fynedo .
       - . /usr/lib/sdk/golang/enable.sh && CGO_LDFLAGS=-L/app/lib /app/bin/fyne package
-        -os linux -name Supersonic -icon ./res/appicon-512.png
+        -os linux -name Supersonic -icon ./res/appicon-512.png -tags migrated_fynedo
       - tar -C /app --strip-components=1 -x -v -f /run/build/supersonic/Supersonic.tar.xz
       - mkdir -p /app/share/icons/hicolor/512x512/apps/
       - mv /app/share/pixmaps/Supersonic.png /app/share/icons/hicolor/512x512/apps/


### PR DESCRIPTION
Fyne 2.6 introduces a reworked threading model where Fyne APIs are only allowed to be invoked from a single thread. The build tag `migrated_fynedo` informs the conditional compilation to *not* include safeguards that try to maintain backward-compatibility with multithreaded access but make the app slower.